### PR TITLE
VIVITA, Inc. -> VIVIWARE JAPAN, Inc and rename package_vivita_index.json -> package_viviware_index.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,11 +65,11 @@ jobs:
           command: |
             date
       - run:
-          name: Commit and push bin files
+          name: Commit and push package json with tagged version
           command: |
             git checkout master
 
-            PACKAGE_JSON='./package_vivita_index.json'
+            PACKAGE_JSON='./package_viviware_index.json'
             ARCHIVE_NAME=${CIRCLE_PROJECT_REPONAME}-${CIRCLE_TAG}.zip
             wget https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/archive/refs/tags/${CIRCLE_TAG}.zip -O ${ARCHIVE_NAME}
             ARCHIVE_SUM=$(shasum -a 256 ${ARCHIVE_NAME} | cut -d' ' -f 1)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This configuration is based on [Pololu A-Star configuration](https://github.com/
 Refer to [README on VivicoreSerial library](https://github.com/vivitainc/VivicoreSerial#how-to-setup).
 
 # Version history
+- 6.0.1 (2021-06-23): VIVITA, Inc. -> VIVIWARE JAPAN, Inc.
+                      and rename package_vivita_index.json -> package_viviware_index.json.
 - 6.0.0 (2021-04-01): Add customized ATmegaBOOT
                       and support VIVIWARE Cell Custom and Branch boards.
 - 4.0.2 (2018-04-17): Fixed an unquoted path in build flags that could cause an

--- a/package_viviware_index.json
+++ b/package_viviware_index.json
@@ -3,7 +3,7 @@
     {
       "name": "viviware",
       "maintainer": "VIVIWARE JAPAN, Inc.",
-      "email": "info@viviware.com",
+      "email": "viviware-support@viviware.com",
       "websiteURL": "https://vivita.co/",
       "platforms": [],
       "tools": []

--- a/package_viviware_index.json
+++ b/package_viviware_index.json
@@ -3,9 +3,8 @@
     {
       "name": "viviware",
       "maintainer": "VIVITA, Inc.",
-      "websiteURL": "https://vivita.co/",
       "email": "info@vivita.co",
-
+      "websiteURL": "https://vivita.co/",
       "platforms": [],
       "tools": []
     }

--- a/package_viviware_index.json
+++ b/package_viviware_index.json
@@ -2,8 +2,8 @@
   "packages": [
     {
       "name": "viviware",
-      "maintainer": "VIVITA, Inc.",
-      "email": "info@vivita.co",
+      "maintainer": "VIVIWARE JAPAN, Inc.",
+      "email": "info@viviware.com",
       "websiteURL": "https://vivita.co/",
       "platforms": [],
       "tools": []

--- a/platform.txt
+++ b/platform.txt
@@ -1,5 +1,5 @@
 name=VIVIWARE Cell
-version=6.0.0
+version=6.0.1
 
 tools.avrdudecustom.path={runtime.tools.avrdude.path}
 tools.avrdudecustom.cmd.path={path}/bin/avrdude


### PR DESCRIPTION
# 対応したRedmineチケット
- [Update VIVIWARE library/board package information #4009](https://support.vivita.io/issues/4009)
# 関連PR
- https://github.com/vivitainc/branch_cell/pull/191 : (No hex change) Rename package json, change VIVITA to VIVIWARE JAPAN, and publish API document to public repository
# 残件
- [x] develop -> master へのマージ
  - 本PRマージ後に実施
- [x] 本リポジトリCI動作チェック
  - タグ付けをトリガーにmasterのpackage jsonを自動更新するため、その動作確認
- [x] 関連PRの動作チェック
  - 自動更新後のpackage jsonとの組み合わせで、最新branch_cellのビルド、バイナリ差分ないことを確認
- [x] public VivicoreSerialリポジトリ記載のpackage json URL更新
  - 一旦手動で書き換えてcommit pushします
- [x] esa記載のpackage json URL更新
- ~~arduino docker同梱packageを6.0.1に更新~~
  - 機能的な差はないのでスキップ
# 参考情報
- v7以降のbranch FWをflashするだけならboard package json設定とboard packageインストール不要
  - build.shのみ、board package内のbootloader hexファイルやboard config、ピン定義ファイルを参照する
- 上記により、[VI001](https://vivita.esa.io/posts/6249)の `package_pololu_index.json` を `package_vivita_index.json` や `package_viviware_index.json` に書き換える必要はない
  - package json関連の手順を残しても、v7以降のflasher/fwupdate.shは参照しないので動作に影響しないが、最終的には削除したい