### PR TITLE
Release VIVIWARE Cell board package 6.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This configuration is based on [Pololu A-Star configuration](https://github.com/
 Refer to [README on VivicoreSerial library](https://github.com/vivitainc/VivicoreSerial#how-to-setup).
 
 # Version history
+- 6.0.1 (2021-06-23): VIVITA, Inc. -> VIVIWARE JAPAN, Inc.
+                      and rename package_vivita_index.json -> package_viviware_index.json.
 - 6.0.0 (2021-04-01): Add customized ATmegaBOOT
                       and support VIVIWARE Cell Custom and Branch boards.
 - 4.0.2 (2018-04-17): Fixed an unquoted path in build flags that could cause an

--- a/package_viviware_index.json
+++ b/package_viviware_index.json
@@ -3,7 +3,7 @@
     {
       "name": "viviware",
       "maintainer": "VIVIWARE JAPAN, Inc.",
-      "email": "info@viviware.com",
+      "email": "viviware-support@viviware.com",
       "websiteURL": "https://vivita.co/",
       "platforms": [],
       "tools": []

--- a/package_viviware_index.json
+++ b/package_viviware_index.json
@@ -2,8 +2,8 @@
   "packages": [
     {
       "name": "viviware",
-      "maintainer": "VIVITA, Inc.",
-      "email": "info@vivita.co",
+      "maintainer": "VIVIWARE JAPAN, Inc.",
+      "email": "info@viviware.com",
       "websiteURL": "https://vivita.co/",
       "platforms": [],
       "tools": []

--- a/platform.txt
+++ b/platform.txt
@@ -1,5 +1,5 @@
 name=VIVIWARE Cell
-version=6.0.0
+version=6.0.1
 
 tools.avrdudecustom.path={runtime.tools.avrdude.path}
 tools.avrdudecustom.cmd.path={path}/bin/avrdude


### PR DESCRIPTION
- 5fb970b でpackage jsonファイル名を `package_vivita_index.json` -> `package_viviware_index.json` に変更したことで、develop -> master のマージでコンフリクトが発生しましたが、一旦上記をmasterにマージして解消済みです。
  - これに伴い、public VivicoreSerialリポジトリのREADME記載のURLのみ、[手動で更新済み](https://github.com/vivitainc/VivicoreSerial/commit/c0631f9f4071fd6a33c25f514c6b66d01cd2cb72)です。
- masterにマージ後、正式な6.0.1としてタグ付けします。
タグ付けをトリガーに、CIがpackage_viviware_index.jsonを更新、Board Manager経由でインストールが可能になります。

# 6.0.0との差分
- VIVITA, Inc. -> VIVIWARE JAPAN, Inc. に変更
- package jsonファイル名 (URL)を package_vivita_index.json -> package_viviware_index.json に変更

# 関連PR
- VIVITA, Inc. -> VIVIWARE JAPAN, Inc and rename package_vivita_index.json -> package_viviware_index.json #5