### PR TITLE
Add PIN_VIVIWARE_VERSION to read version of board

### DIFF
--- a/variants/cell-328pb/pins_arduino.h
+++ b/variants/cell-328pb/pins_arduino.h
@@ -110,6 +110,7 @@ static const uint8_t A7 = PIN_A7;
 #define PIN_VIVIWARE_EN_TX     (23)
 #define PIN_VIVIWARE_EN_PWR    (22)
 #define PIN_VIVIWARE_DEBUG_LED (6)
+#define PIN_VIVIWARE_VERSION   (A6)
 #elif (BOARD_TYPE == BOARD_TYPE_DEPRECATED_CUSTOM)
 #define LED_BUILTIN            (13)
 #define PIN_VIVIWARE_EN_RX     (22)


### PR DESCRIPTION
# 対応したRedmineチケット
- [#6700 Detect board version with port A6_VER](https://support.vivita.io/issues/6700)

# 関連PR
- https://github.com/vivitainc/branch_cell/pull/243
- https://github.com/vivitainc/dockerfiles_fwteam/pull/22

# 修正概略
- Custom Cell向けに `PIN_VIVIWARE_VERSION` 定義を追加