### PR TITLE
Fix warning to clear lock bits at writing bootloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This configuration is based on [Pololu A-Star configuration](https://github.com/
 Refer to [README on VivicoreSerial library](https://github.com/vivitainc/VivicoreSerial#how-to-setup).
 
 # Version history
+- 6.3.2-rc1 (2023-10-01): Fix warning to clear lock bits at writing bootloader
 - 6.3.1 (2023-02-19): Add pin definition PIN_VIVIWARE_VERSION for VIVIWARE Custom Cell v4 board or later.
 - 6.3.0 (2023-01-28): Support VIVIWARE Custom Cell v4 board, v3 is deprecated, and v1-v2 are dropped.
 - 6.2.0 (2022-06-19): Support VIVIWARE Custom Cell v3 board, v1-v2 are deprecated.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This configuration is based on [Pololu A-Star configuration](https://github.com/
 Refer to [README on VivicoreSerial library](https://github.com/vivitainc/VivicoreSerial#how-to-setup).
 
 # Version history
-- 6.3.2-rc1 (2023-10-01): Fix warning to clear lock bits at writing bootloader
+- 6.3.2-rc3 (2023-10-01): Fix warning to clear lock bits at writing bootloader
 - 6.3.1 (2023-02-19): Add pin definition PIN_VIVIWARE_VERSION for VIVIWARE Custom Cell v4 board or later.
 - 6.3.0 (2023-01-28): Support VIVIWARE Custom Cell v4 board, v3 is deprecated, and v1-v2 are dropped.
 - 6.2.0 (2022-06-19): Support VIVIWARE Custom Cell v3 board, v1-v2 are deprecated.

--- a/boards.txt
+++ b/boards.txt
@@ -12,7 +12,7 @@ cell-328pb.bootloader.tool=avrdudecustom
 cell-328pb.bootloader.low_fuses=0xFF
 cell-328pb.bootloader.high_fuses=0xD2
 cell-328pb.bootloader.extended_fuses=0xF5
-cell-328pb.bootloader.unlock_bits=0xFF
+cell-328pb.bootloader.unlock_bits=0x3F
 cell-328pb.bootloader.lock_bits=0x0F
 
 #cell-328pb.build.mcu=atmega328pb

--- a/boards.txt
+++ b/boards.txt
@@ -12,7 +12,6 @@ cell-328pb.bootloader.tool=avrdudecustom
 cell-328pb.bootloader.low_fuses=0xFF
 cell-328pb.bootloader.high_fuses=0xD2
 cell-328pb.bootloader.extended_fuses=0xF5
-cell-328pb.bootloader.unlock_bits=0x3F
 cell-328pb.bootloader.lock_bits=0x0F
 
 #cell-328pb.build.mcu=atmega328pb

--- a/platform.txt
+++ b/platform.txt
@@ -12,7 +12,7 @@ tools.avrdudecustom.upload.pattern="{cmd.path}" "-C{config.path}" {upload.verbos
 
 tools.avrdudecustom.erase.params.verbose=-v
 tools.avrdudecustom.erase.params.quiet=-q -q
-tools.avrdudecustom.erase.pattern="{cmd.path}" "-C{config.path}" {erase.verbose} -p{upload.mcu} -c{protocol} {program.extra_params} -B 5 -e -Ulock:w:{bootloader.unlock_bits}:m -Uefuse:w:{bootloader.extended_fuses}:m -Uhfuse:w:{bootloader.high_fuses}:m -Ulfuse:w:{bootloader.low_fuses}:m
+tools.avrdudecustom.erase.pattern="{cmd.path}" "-C{config.path}" {erase.verbose} -p{upload.mcu} -c{protocol} {program.extra_params} -B 5 -e -Uefuse:w:{bootloader.extended_fuses}:m -Uhfuse:w:{bootloader.high_fuses}:m -Ulfuse:w:{bootloader.low_fuses}:m
 
 tools.avrdudecustom.program.params.verbose=-v
 tools.avrdudecustom.program.params.quiet=-q -q

--- a/platform.txt
+++ b/platform.txt
@@ -1,5 +1,5 @@
 name=VIVIWARE Cell
-version=6.2.0
+version=6.3.2
 
 tools.avrdudecustom.path={runtime.tools.avrdude.path}
 tools.avrdudecustom.cmd.path={path}/bin/avrdude


### PR DESCRIPTION
# Redmine

https://support.vivita.io/issues/7540

# 補足

製品Branchのbootloader焼き直し等の対応は不要。
本件は、bootloader書き込み前のchip erase時に冗長な設定が含まれていたのが原因だったため。

# 対策後の動作確認手順

1. VIVIWARE Cell Custom Boards 6.3.2-rc3 をインストールする
2. PCにArduino ISPジグを接続し、Custom Cell等にbootloaderを書き込む
3. 対策前はbootloader書き込み時に出力された以下のログが、対策後は出力されないことを確認する

    ```
    avrdude: WARNING: invalid value for unused bits in fuse "lock", should be set to 1 according to datasheet
    This behaviour is deprecated and will result in an error in future version
    You probably want to use 0x3f instead of 0xff (double check with your datasheet first).
    ```

4. 念のため、対策後もbootloader領域が意図通り保護されていることを確認する
    1. 対策後の環境でbootloaderを書き込んだCustom Cellを用意する
    2. 意図的にbootloader領域を超えるユーザプログラムを作成してuploadすると、以下のログが出力されることを確認する（bootloader領域のflashに書き込めなかったことを示す）

        ```
        avrdude: verifying ...
        avrdude: verification error, first mismatch at byte 0x7800
                 0x0c != 0x49
        avrdude: verification error; content mismatch
        ```

    3. bootloader領域を超えるユーザプログラムをuploadし直すと、以下のログが出力され、ユーザプログラムも正常に動作することを確認する

        ```
        avrdude: verifying ...
        avrdude: 30278 bytes of flash verified
        ```

# 原因と対策

[データシート](https://ww1.microchip.com/downloads/aemDocuments/documents/MCU08/ProductDocuments/DataSheets/40001906C.pdf#page=384)に記載の通り、328pbがサポートするlock bit定義は0-5bitまでであるにも関わらず、6-7bitの設定をunlock_bitsに含めていたためにwarningが出ていた。
このunlock_bits値は[custom_cell_boardsのboards.txt](https://github.com/vivitainc/custom_cell_boards/blob/f5262fd5a8892248ea85215680b8a08da3fb2755/boards.txt#L11-L16)に以下のように定義しているが、
```
cell-328pb.bootloader.tool=avrdudecustom
cell-328pb.bootloader.low_fuses=0xFF
cell-328pb.bootloader.high_fuses=0xD2
cell-328pb.bootloader.extended_fuses=0xF5
cell-328pb.bootloader.unlock_bits=0xFF
cell-328pb.bootloader.lock_bits=0x0F
```

そもそもlock bitsはchip eraseでのみクリア可能であり、unlock_bitsをchip erase時に指定していること自体が無意味であるため、以下のように対応した。

## 修正前

bootloader書き込み前に実施するchip eraseコマンド:
- -e はchip erase
- -Ulock:w:0xFF:m はlock bitsに0xFFを設定

```
"/Users/takashi/Library/Arduino15/packages/arduino/tools/avrdude/6.3.0-arduino17/bin/avrdude" "-C/Users/takashi/Library/Arduino15/packages/arduino/tools/avrdude/6.3.0-arduino17/etc/avrdude.conf" -v -patmega328pb -cstk500v1 -P/dev/cu.usbserial-1410 -b19200 -B 5 -e -Ulock:w:0xFF:m -Uefuse:w:0xF5:m -Uhfuse:w:0xD2:m -Ulfuse:w:0xFF:m
```

## 修正後

bootloader書き込み前に実施するchip eraseコマンド:
- -e はchip erase（変更なし）
- -Ulock:w:0xFF:m を削除

```
"/Users/takashi/Library/Arduino15/packages/arduino/tools/avrdude/6.3.0-arduino17/bin/avrdude" "-C/Users/takashi/Library/Arduino15/packages/arduino/tools/avrdude/6.3.0-arduino17/etc/avrdude.conf" -v -patmega328pb -cstk500v1 -P/dev/cu.usbserial-1410 -b19200 -B 5 -e -Uefuse:w:0xF5:m -Uhfuse:w:0xD2:m -Ulfuse:w:0xFF:m
```
